### PR TITLE
Add support for loongarch64

### DIFF
--- a/paryfor.hpp
+++ b/paryfor.hpp
@@ -60,6 +60,15 @@ static inline void spin_loop_pause() noexcept {
 }
 } // namespace atomic_queue
 } // namespace paryfor
+#elif defined(__loongarch64)
+namespace paryfor {
+namespace atomic_queue {
+constexpr int CACHE_LINE_SIZE = 64;
+static inline void spin_loop_pause() noexcept {
+    asm volatile ("nop" ::: "memory");
+}
+} // namespace atomic_queue
+} // namespace paryfor
 #else
 #error "Unknown CPU architecture."
 #endif


### PR DESCRIPTION
Compiling the paryfor failed (failed five times in the past) for loong64 in the Debian Package Auto-Building environment.
The error log is as follows,
```
In file included from /<<PKGBUILDDIR>>/test.cpp:5:
/<<PKGBUILDDIR>>/paryfor.hpp:64:2: error: #error "Unknown CPU architecture."
   64 | #error "Unknown CPU architecture."
      |  ^~~~~
......
```

The Full log can be found at https://buildd.debian.org/status/logs.php?pkg=paryfor&ver=0.1-7&arch=loong64.

I have added support for loongarch in paryfor package and built successfully on my local ENV.
Please review.
